### PR TITLE
Rename package from wavefront_plugin to wavefront

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 func main() {
 	plugin.Serve(&plugin.ServeOpts{
 		ProviderFunc: func() terraform.ResourceProvider {
-			return wavefront_plugin.Provider()
+			return wavefront.Provider()
 		},
 	})
 }

--- a/wavefront/common.go
+++ b/wavefront/common.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"fmt"

--- a/wavefront/data_source_default_user_group.go
+++ b/wavefront/data_source_default_user_group.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"fmt"

--- a/wavefront/import_alert_target_test.go
+++ b/wavefront/import_alert_target_test.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"testing"

--- a/wavefront/import_alert_test.go
+++ b/wavefront/import_alert_test.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"testing"

--- a/wavefront/import_cloud_integration_test.go
+++ b/wavefront/import_cloud_integration_test.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"github.com/WavefrontHQ/go-wavefront-management-api"

--- a/wavefront/import_dashboard_json_test.go
+++ b/wavefront/import_dashboard_json_test.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"fmt"

--- a/wavefront/import_dashboard_test.go
+++ b/wavefront/import_dashboard_test.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"testing"

--- a/wavefront/import_derived_metric_test.go
+++ b/wavefront/import_derived_metric_test.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"fmt"

--- a/wavefront/import_role_test.go
+++ b/wavefront/import_role_test.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"github.com/WavefrontHQ/go-wavefront-management-api"

--- a/wavefront/import_user_group_test.go
+++ b/wavefront/import_user_group_test.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"fmt"

--- a/wavefront/import_user_test.go
+++ b/wavefront/import_user_test.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"fmt"

--- a/wavefront/provider.go
+++ b/wavefront/provider.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"fmt"

--- a/wavefront/provider_test.go
+++ b/wavefront/provider_test.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"testing"

--- a/wavefront/resource_alert.go
+++ b/wavefront/resource_alert.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"fmt"

--- a/wavefront/resource_alert_target.go
+++ b/wavefront/resource_alert_target.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"fmt"

--- a/wavefront/resource_alert_target_test.go
+++ b/wavefront/resource_alert_target_test.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"fmt"

--- a/wavefront/resource_alert_test.go
+++ b/wavefront/resource_alert_test.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"fmt"

--- a/wavefront/resource_cloud_integration.go
+++ b/wavefront/resource_cloud_integration.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"fmt"

--- a/wavefront/resource_cloud_integration_app_dynamics.go
+++ b/wavefront/resource_cloud_integration_app_dynamics.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/wavefront/resource_cloud_integration_app_dynamics_test.go
+++ b/wavefront/resource_cloud_integration_app_dynamics_test.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"fmt"

--- a/wavefront/resource_cloud_integration_aws_external_id.go
+++ b/wavefront/resource_cloud_integration_aws_external_id.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"fmt"

--- a/wavefront/resource_cloud_integration_aws_external_id_test.go
+++ b/wavefront/resource_cloud_integration_aws_external_id_test.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"fmt"

--- a/wavefront/resource_cloud_integration_azure.go
+++ b/wavefront/resource_cloud_integration_azure.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/wavefront/resource_cloud_integration_azure_activity_log.go
+++ b/wavefront/resource_cloud_integration_azure_activity_log.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/wavefront/resource_cloud_integration_azure_activity_log_test.go
+++ b/wavefront/resource_cloud_integration_azure_activity_log_test.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"fmt"

--- a/wavefront/resource_cloud_integration_azure_test.go
+++ b/wavefront/resource_cloud_integration_azure_test.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"fmt"

--- a/wavefront/resource_cloud_integration_cloudtrail.go
+++ b/wavefront/resource_cloud_integration_cloudtrail.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/wavefront/resource_cloud_integration_cloudtrail_test.go
+++ b/wavefront/resource_cloud_integration_cloudtrail_test.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"fmt"

--- a/wavefront/resource_cloud_integration_cloudwatch.go
+++ b/wavefront/resource_cloud_integration_cloudwatch.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/wavefront/resource_cloud_integration_cloudwatch_test.go
+++ b/wavefront/resource_cloud_integration_cloudwatch_test.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"fmt"

--- a/wavefront/resource_cloud_integration_ec2.go
+++ b/wavefront/resource_cloud_integration_ec2.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/wavefront/resource_cloud_integration_ec2_test.go
+++ b/wavefront/resource_cloud_integration_ec2_test.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"fmt"

--- a/wavefront/resource_cloud_integration_gcp.go
+++ b/wavefront/resource_cloud_integration_gcp.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/wavefront/resource_cloud_integration_gcp_billing.go
+++ b/wavefront/resource_cloud_integration_gcp_billing.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import "github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 

--- a/wavefront/resource_cloud_integration_gcp_billing_test.go
+++ b/wavefront/resource_cloud_integration_gcp_billing_test.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"fmt"

--- a/wavefront/resource_cloud_integration_gcp_test.go
+++ b/wavefront/resource_cloud_integration_gcp_test.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"fmt"

--- a/wavefront/resource_cloud_integration_newrelic.go
+++ b/wavefront/resource_cloud_integration_newrelic.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import "github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 

--- a/wavefront/resource_cloud_integration_newrelic_test.go
+++ b/wavefront/resource_cloud_integration_newrelic_test.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"fmt"

--- a/wavefront/resource_cloud_integration_tesla.go
+++ b/wavefront/resource_cloud_integration_tesla.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import "github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 

--- a/wavefront/resource_cloud_integration_tesla_test.go
+++ b/wavefront/resource_cloud_integration_tesla_test.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"fmt"

--- a/wavefront/resource_cloud_integration_test.go
+++ b/wavefront/resource_cloud_integration_test.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"fmt"

--- a/wavefront/resource_dashboad_json.go
+++ b/wavefront/resource_dashboad_json.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"fmt"

--- a/wavefront/resource_dashboard.go
+++ b/wavefront/resource_dashboard.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"fmt"

--- a/wavefront/resource_dashboard_json_test.go
+++ b/wavefront/resource_dashboard_json_test.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"fmt"

--- a/wavefront/resource_dashboard_test.go
+++ b/wavefront/resource_dashboard_test.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"fmt"

--- a/wavefront/resource_derived_metric.go
+++ b/wavefront/resource_derived_metric.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"fmt"

--- a/wavefront/resource_derived_metric_test.go
+++ b/wavefront/resource_derived_metric_test.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"fmt"

--- a/wavefront/resource_role.go
+++ b/wavefront/resource_role.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"fmt"

--- a/wavefront/resource_role_test.go
+++ b/wavefront/resource_role_test.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"fmt"

--- a/wavefront/resource_user.go
+++ b/wavefront/resource_user.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"fmt"

--- a/wavefront/resource_user_group.go
+++ b/wavefront/resource_user_group.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"fmt"

--- a/wavefront/resource_user_group_test.go
+++ b/wavefront/resource_user_group_test.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"fmt"

--- a/wavefront/resource_user_test.go
+++ b/wavefront/resource_user_test.go
@@ -1,4 +1,4 @@
-package wavefront_plugin
+package wavefront
 
 import (
 	"fmt"


### PR DESCRIPTION
This ensures there is consistency between the package folder structure
and the package name. This is important for users who are using the SDK
directly rather than just the CLI based tool

There is no functionality changes in this PR - it is merely mechanical
renaming